### PR TITLE
修改無填滿 style 的標籤 radius

### DIFF
--- a/src/containers/ScheduleDetail/InnerTag.js
+++ b/src/containers/ScheduleDetail/InnerTag.js
@@ -4,7 +4,7 @@ import styled from 'styled-components/native';
 const KeynoteContainer = styled.View`
   padding: 2px 6px;
   background-color: ${p => p.bg};
-  border-radius: 3px;
+  border-radius: 15px;
   border: 1px;
   border-color: ${p => p.bdc};
   margin-right: 10px;


### PR DESCRIPTION
無填滿 style 標籤 radius 已經修改完成。
但有一個問題，
無填滿 style 標籤總共有三種，Keynote 的設計稿上面沒有，無法確認。

- [x] 議程夥伴
- [x] 禁止攝影
- [ ] Keynote