### PR TITLE
修正跳頁參數傳遞

### DIFF
--- a/src/containers/Community/Community.js
+++ b/src/containers/Community/Community.js
@@ -68,7 +68,7 @@ const Community = ({ navigation }) => {
             <React.Fragment>
               <Style.Container>
                 <Style.TabContainer>
-                  <TabDate tabs={tabs} defaultActiveTab={tab} onChange={setTab(tab)} />
+                  <TabDate tabs={tabs} defaultActiveTab={tab} onChange={setTab} />
                 </Style.TabContainer>
                 {
                   tab === 'community'

--- a/src/containers/CommunityDetail/CommunityDetail.js
+++ b/src/containers/CommunityDetail/CommunityDetail.js
@@ -8,9 +8,9 @@ import IconIG from '../../images/icon/icon_ig.png';
 import IconTe from '../../images/icon/icon_tw.png';
 import IconTw from '../../images/icon/icon_tw.png';
 import NavigationOptions from '../../components/NavigationOptions/NavigationOptions';
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 
-const CommunityDetail = ({ navigation }) => {
+const CommunityDetail = ({ navigation, route }) => {
   const [ community, setCommunity ] = React.useState({})
 
   React.useEffect(() => {
@@ -19,7 +19,7 @@ const CommunityDetail = ({ navigation }) => {
       setCommunity(community);
     }
 
-    const { url } = navigation.state.params;
+    const { url } = route.params;
     getDetail(url);
   }, [])
 
@@ -110,5 +110,6 @@ const CommunityDetail = ({ navigation }) => {
 CommunityDetail.navigationOptions = ({ navigation }) => NavigationOptions(navigation, 'community.community_info', 'mode2')
 export default function (props) {
   const navigation = useNavigation();
-  return <CommunityDetail {...props} navigation={navigation} />
+  const route = useRoute();
+  return <CommunityDetail {...props} navigation={navigation} route={route} />
 }

--- a/src/containers/MissionDetail/MissionDetail.js
+++ b/src/containers/MissionDetail/MissionDetail.js
@@ -3,10 +3,10 @@ import NavigationOptions from '../../components/NavigationOptions/NavigationOpti
 import Quiz from './Quiz';
 import QRCode from './QRCode';
 import * as Style from './style';
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 
-const MissionDetail = ({ navigation }) => {
-  const { id, type } = navigation.state.params;
+const MissionDetail = ({ navigation, route }) => {
+  const { id, type } = route.params;
   return (
     <Style.MissionContainer>
       {
@@ -24,5 +24,6 @@ const MissionDetail = ({ navigation }) => {
 MissionDetail.navigationOptions = ({ navigation }) => NavigationOptions(navigation, `missionDetail.${navigation.state.params.type}`, 'mode2')
 export default function (props) {
   const navigation = useNavigation();
-  return <MissionDetail {...props} navigation={navigation} />
+  const route = useRoute();
+  return <MissionDetail {...props} navigation={navigation} route={route} />
 }

--- a/src/containers/SpeakerDetail/SpeakerDetail.js
+++ b/src/containers/SpeakerDetail/SpeakerDetail.js
@@ -11,11 +11,11 @@ import iconGithub from '../../images/icon/icon_gh.png';
 import iconTwitter from '../../images/icon/icon_tw.png';
 import iconOther from '../../images/icon/icon_web.png';
 import * as Style from './style';
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 
 const toTime = timestamp => moment(timestamp).format('HH:mm');
 const toDate = timestamp => moment(timestamp)
-const SpeakerDetail = ({ navigation }) => {
+const SpeakerDetail = ({ navigation, route }) => {
 
   const [ savedSchedule, setSavedSchedule ] = React.useState({})
   const [ state, setState ] = React.useState({
@@ -54,7 +54,7 @@ const SpeakerDetail = ({ navigation }) => {
   }
 
   const { isReadMore } = state;
-  const { speakerDetail } = navigation.state.params;
+  const speakerDetail = route.params?.speakerDetail ?? {};
 
   const name = I18n.locale === 'en' ? speakerDetail.name_e : speakerDetail.name;
   const info = I18n.locale === 'en' ? speakerDetail.bio_e : speakerDetail.bio;
@@ -141,5 +141,6 @@ const SpeakerDetail = ({ navigation }) => {
 SpeakerDetail.navigationOptions = ({ navigation }) => NavigationOptions(navigation, 'speaker.title', 'mode2')
 export default function (props) {
   const navigation = useNavigation();
-  return <SpeakerDetail {...props} navigation={navigation} />
+  const route = useRoute();
+  return <SpeakerDetail {...props} navigation={navigation} route={route} />
 }

--- a/src/containers/SponsorDetail/SponsorDetail.js
+++ b/src/containers/SponsorDetail/SponsorDetail.js
@@ -7,7 +7,7 @@ import ScheduleCard from '../../components/ScheduleItem/ScheduleCard';
 import gameServices from '../../api/gameServices';
 import I18n from '../../locales';
 import * as Style from './style';
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 
 const toTime = timestamp => moment(timestamp).format('HH:mm')
 
@@ -21,7 +21,7 @@ const normalizeScheduleData = (originScheduleData, savedSchedule) => ({
   title_e: originScheduleData.topic_name_e,
 });
 
-const SponsorDetail = ({ navigation }) => {
+const SponsorDetail = ({ navigation, route }) => {
 
   const [ savedSchedule, setSavedSchedule ] = React.useState({})
 
@@ -59,7 +59,7 @@ const SponsorDetail = ({ navigation }) => {
     AsyncStorage.setItem('savedschedule', JSON.stringify(_savedSchedule));
   }
 
-  const { sponsorDetail } = navigation.state.params;
+  const sponsorDetail = route.params?.sponsorDetail ?? {};
   const name = I18n.locale === 'zh' ? sponsorDetail.name : sponsorDetail.name_e;
   const info = I18n.locale === 'zh' ? sponsorDetail.about_us : sponsorDetail.about_us_e;
   const logo = sponsorDetail.logo_path;
@@ -112,5 +112,6 @@ const SponsorDetail = ({ navigation }) => {
 SponsorDetail.navigationOptions = ({ navigation }) => NavigationOptions(navigation, 'sponsor.info', 'mode2')
 export default function (props) {
   const navigation = useNavigation();
-  return <SponsorDetail {...props} navigation={navigation} />
+  const route = useRoute();
+  return <SponsorDetail {...props} navigation={navigation} route={route} />
 }

--- a/src/containers/VolunteerDetail/VolunteerDetail.js
+++ b/src/containers/VolunteerDetail/VolunteerDetail.js
@@ -6,9 +6,9 @@ import I18n from '../../locales';
 import NavigationOptions from '../../components/NavigationOptions/NavigationOptions';
 import { AVATAR } from '../Community/VolunteerBlock';
 import apiServices from '../../api/services';
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 
-const VolunteerDetail = ({ navigation }) => {
+const VolunteerDetail = ({ navigation, route }) => {
 
   const [ volunteer, setVolunteer ] = React.useState({ members: [] })
 
@@ -18,7 +18,7 @@ const VolunteerDetail = ({ navigation }) => {
   }
 
   React.useEffect(() => {
-    const { url, id } = navigation.state.params;
+    const { url, id } = route.params;
     fetchVolunteerDetail(url);
   })
 
@@ -49,6 +49,7 @@ const VolunteerDetail = ({ navigation }) => {
 VolunteerDetail.navigationOptions = ({ navigation }) => NavigationOptions(navigation, 'community.volunteer_info', 'mode2')
 export default function (props) {
   const navigation = useNavigation();
-  return <VolunteerDetail {...props} navigation={navigation} />
+  const route = useRoute()
+  return <VolunteerDetail {...props} navigation={navigation} route={route} />
 }
 


### PR DESCRIPTION
礙於 v5 API，參數傳遞須改寫
[出處](https://reactnavigation.org/docs/upgrading-from-4.x/#no-more-getparam)

```jsx
navigation.state.params('key', defaultValue)
```

改成 

```jsx
route.params?.key ?? 'defaultValue';
```

- 修正 Issue `Speaker 和 Sponsor 頁面參數無法傳到下一頁` #292 
- 同上修正 MissionDetail, CommunityDetail, VolunteerDetail
- 修正 Community 潛藏的 re-render issue